### PR TITLE
Matching tag with semver

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Deploy to now](https://deploy.now.sh/static/button.svg)](https://deploy.now.sh/?repo=https://github.com/Contextualist/glare)
 
-A little service for you to **g**et **la**test **re**leases from GitHub gracefully. Simply make a get request to Glare with the repo name and release file name regex, and she will lead you to the way.
+A little service for you to download releases from GitHub gracefully. Simply make a get request to Glare with the repo name (with an optional version) and release file name regex, and she will lead you to the way.
 
 **NOTE:** You might want to use [GitHub's direct link](https://help.github.com/en/articles/linking-to-releases#linking-to-the-latest-release) to the latest release asset (e.g. `github.com/{owner}/{repo}/releases/latest/download/asset-name.zip`) if the asset name is a constant string. Otherwise Glare is still helpful for matching the asset with regex.
 
@@ -12,16 +12,24 @@ The following will redirect you to `https://github.com/xtaci/kcptun/releases/dow
 curl -fLO https://glare.now.sh/xtaci/kcptun/linux-amd64
 ```
 
+Or you might want to have a version constraint:
+```bash
+curl -fLO https://glare.now.sh/dhall/dhall-haskell@~1.24.x/bash.*linux
+```
+
 ## Motivation
 Sometimes when I'm writing a Dockerfile, I need to install packages from their GitHub latest releases. A neat way is to parse JSON responses from GitHub API with [`jq`](https://stedolan.github.io/jq) and get the desire link. Such way requires downlaoding `jq` from GitHub (The binary from Alpine apk is lack of regex feature). Still, the expression with `jq` is not clear enough, and parsing JSON with `sed` is way dirtier. So I spend a little time to write Glare. I hope she will save you a few minutes or from a frustring moment.
 
 ## Usage
 ```
+# To get the latest release...
 /{owner}/{repo}/{file_name_regex}
+
+# To get a specific version or pick within a version range...
+/{owner}/{repo}@{tag|semver}/{file_name_regex}
 ```
 `{file_name_regex}` is a regular expression to match the file (or specially, it can be `tar` or `zip` standing for the source code download in the respective format). It should match at least one file among the latest release files, otherwise Glare will throw an error. If multiple files are matched, Glare returns the one with shortest length.
 
-Tip: to check if a request leads to the desired redirection, `curl` it without any option.
+If `{tag}` is given, Glare looks for a release with exact matching tag. For `{semver}` provided, Glare treats it as a [npm-flavor semver](https://semver.npmjs.com/) and matches all release tag names against it. The highest of all satisfied versions is chosen.
 
-## Docker (legacy version)
-See branch [`docker`](https://github.com/Contextualist/glare/tree/docker)
+Tip: to check if a request leads to the desired redirection, `curl` it without any option.

--- a/main.py
+++ b/main.py
@@ -1,31 +1,54 @@
 from flask import Flask, jsonify, redirect
 import requests
+import semver
 import re
 
 app = Flask(__name__)
 
-@app.route('/<user>/<repo>/<name_re>')
-def get_latest_release(user, repo, name_re):
+@app.route('/<user>/<repo_ver>/<name_re>')
+def get_release(user, repo_ver, name_re):
     try:
         name_reobj = re.compile(name_re)
     except re.error as e:
         return jsonify(message=f"bad regular expression: {e.msg}"), 400
 
-    resp = requests.get(f"https://api.github.com/repos/{user}/{repo}/releases/latest")
-    if resp.status_code != 200:
-        return jsonify(message="error from GitHub api",
-                       github_api_msg=resp.json()), resp.status_code
+    repo_ver = repo_ver.split('@', 1)
+    repo = repo_ver[0]
+    if len(repo_ver) == 2: # versioned
+        ver = repo_ver[1]
+        all_releases, err = api_req(f"https://api.github.com/repos/{user}/{repo}/releases")
+        if err: return err
+        all_tags = [x['tag_name'] for x in all_releases]
+        if ver in all_tags: # exact match
+            tag = f"tags/{ver}"
+        else:
+            try:
+                v = semver.max_satisfying(all_tags, ver)
+            except Exception as e:
+                return jsonify(message=f"error matching the tag: {e}"), 400
+            if v is None:
+                return jsonify(message="no tag matched"), 404
+            tag = f"tags/{v}"
+    else:
+        tag = "latest"
+
+    release, err = api_req(f"https://api.github.com/repos/{user}/{repo}/releases/{tag}")
+    if err: return err
 
     if name_re == 'tar':
-        return redirect(resp.json()['tarball_url'])
+        return redirect(release['tarball_url'])
     if name_re == 'zip':
-        return redirect(resp.json()['zipball_url'])
-    assets = resp.json()['assets']
+        return redirect(release['zipball_url'])
+    assets = release['assets']
     matched = [x['browser_download_url'] for x in assets if name_reobj.search(x['name'])]
     if len(matched) == 0:
         return jsonify(message="no file matched"), 404
     matched.sort(key=len)
     return redirect(matched[0])
 
-if __name__ == '__main__':
-    app.run(host='127.0.0.1', port=1080)
+def api_req(url):
+    resp = requests.get(url)
+    if resp.status_code != 200:
+        return None, (jsonify(message="error from GitHub API",
+                              github_api_msg=resp.json()), resp.status_code)
+    return resp.json(), None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask
 requests
+node-semver~=0.7.0


### PR DESCRIPTION
This resolves #1.

This allows the user to specify a release of specific version with a [npm-flavor semver](https://semver.npmjs.com) version constraint or a tag name. If a version constraint is provided, all releases' tag names are matched against that constraint, and the highest possible version is chosen.

API syntaxes:
`/{user}/{repo}/{asset_regex}` (implies latest stable release, backward compatible)
`/{user}/{repo}@{semver|version_tag}/{asset_regex}`
